### PR TITLE
Make elf a noarch: python package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,32 @@
 os: linux
 dist: trusty
 sudo: required
-language: python
+language: generic
 env:
-  - CONDA_PYTHON_VERSION="36"
-  - CONDA_PYTHON_VERSION="37"
+  global:
+    - CONDA_ROOT=$HOME/miniconda
 addons:
   apt:
     update: true
 
-before_script:
+before_install:
   # install conda
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - bash miniconda.sh -b -p $CONDA_ROOT
+  - echo ". $CONDA_ROOT/etc/profile.d/conda.sh" >> ~/.bashrc
+  - source ~/.bashrc
   # update conda
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  # create the test environment
-  - conda create -n elf-env -c conda-forge imageio h5py z5py vigra scikit-image
-  - source activate elf-env
+  - conda install -q conda-build pip
+
+install:
+  - conda build -c conda-forge -c defaults conda-recipe
+
+before_script:
+  - conda create -n test-env --use-local elf
 
 script:
-  - python setup.py install
-  - python -m unittest discover -v test
+  - conda activate test-env
+  - cd test && python -m unittest discover -v .

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,3 +1,5 @@
+{% set data = load_setup_py_data() %}
+
 package:
   name: elf
   {% set tagged_version = GIT_DESCRIBE_TAG|replace("v","")|replace("-", ".") %}
@@ -25,10 +27,13 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - scikit-image
-    - z5py
-    - h5py
-    - imageio
+    # setup.py is source for dependencies. Add/remove there.
+    {% for dep in data['install_requires'] %}
+    - {{ dep.lower().replace('skimage', 'scikit-image') }}
+    {% endfor %}
+    {% for dep in data['extras_require']['all'] %}
+    - {{ dep.lower().replace('skimage', 'scikit-image') }}
+    {% endfor %}
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   {% if GIT_DESCRIBE_NUMBER|int != 0 %}
     {% set tagged_version = tagged_version + '.post' + GIT_DESCRIBE_NUMBER %}
   {% endif %}
-
   version: {{tagged_version}}
 
 
@@ -16,16 +15,16 @@ source:
 
 build:
   number: 0
-  string: py{{py}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
-
+  string: py_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
+  noarch: python
+  script: "pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
-  host:
-    - python {{PY_VER}}*
-
+  build:
+    - python >=3.6
+    - pip
   run:
-    - python {{PY_VER}}*
+    - python >=3.6
     - scikit-image
     - z5py
     - h5py

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ __version__ = runpy.run_path('elf/__version__.py')['__version__']
 # TODO specify all mandatory dependencies
 requires = [
     "numpy",
-    "imageio"
+    "imageio",
+    "skimage"
 ]
 
 # TODO specify all additional dependencies


### PR DESCRIPTION
Since this is Python only we can skip the effort of building it for every platform.

Summary:

* make `elf` a noarch package -> one build for all.
* use `setup.py` for handling dependencies. Those dependencies are automatically picked up by conda-build according to `meta.yaml`.
* adapted travis a bit to also test building elf, and test the built package, rather than the source.