### PR TITLE
Improve flexibility of IO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,128 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
 __pycache__/
-.ipynb_checkpoints/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,11 @@ install:
 
 before_script:
   - conda create -n test-env -c conda-forge -c defaults -c cpape --use-local elf
+  - conda activate test-env
+  - conda install -c conda-forge -c defaults -c cpape nifty
+  - conda install -c conda-forge -c defaults z5py
+  - conda install -c conda-forge -c defaults zarr
+  - pip install pyn5
 
 script:
-  - conda activate test-env
   - cd test && python -m unittest discover -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ install:
 before_script:
   - conda create -n test-env -c conda-forge -c defaults -c cpape --use-local elf
   - conda activate test-env
-  - conda install -c conda-forge -c defaults -c cpape nifty
-  - conda install -c conda-forge -c defaults z5py
+  # we still need to install zarr and pyn5, because they are not included by conda
   - conda install -c conda-forge -c defaults zarr
   - pip install pyn5
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     {% for dep in data['install_requires'] %}
     - {{ dep.lower() }}
     {% endfor %}
-    {% for dep in data['extras_require']['all'] %}
+    {% for dep in data['extras_require']['conda_all'] %}
     - {{ dep.lower() }}
     {% endfor %}
 

--- a/elf/io/extensions.py
+++ b/elf/io/extensions.py
@@ -4,7 +4,7 @@ from .knossos_wrapper import KnossosFile, KnossosDataset
 
 
 __all__ = [
-    "FILE_CONSTRUCTORS", "GROUP_LIKE", "DATASET_LIKE", "h5py", "z5py",
+    "FILE_CONSTRUCTORS", "GROUP_LIKE", "DATASET_LIKE", "h5py", "z5py", "pyn5", "zarr"
 ]
 
 FILE_CONSTRUCTORS = {}
@@ -52,6 +52,23 @@ try:
     register_filetype(z5py.File, N5_EXTS + ZARR_EXTS, z5py.Group, z5py.Dataset)
 except ImportError:
     z5py = None
+
+
+try:
+    # will not override z5py
+    import pyn5
+    register_filetype(pyn5.File, N5_EXTS, pyn5.Group, pyn5.Dataset)
+except ImportError:
+    pyn5 = None
+
+try:
+    # will not override z5py
+    import zarr
+    register_filetype(
+        zarr.open, N5_EXTS + ZARR_EXTS, zarr.hierarchy.Group, zarr.core.Array
+    )
+except ImportError:
+    zarr = None
 
 # Are there any typical knossos extensions?
 # add knossos (no extension)

--- a/elf/io/extensions.py
+++ b/elf/io/extensions.py
@@ -1,31 +1,58 @@
-from .knossos_wrapper import KnossosFile
+import numpy as np
 
-# Kudos to @clbarnes for the extension design
+from .knossos_wrapper import KnossosFile, KnossosDataset
+
+
+__all__ = [
+    "FILE_CONSTRUCTORS", "GROUP_LIKE", "DATASET_LIKE", "h5py", "z5py",
+]
+
 FILE_CONSTRUCTORS = {}
+ZARR_EXTS = [".zarr", ".zr"]
+N5_EXTS = [".n5"]
+
+GROUP_LIKE = []
+DATASET_LIKE = [np.ndarray]
 
 
-def register_filetype(constructor, *extensions):
-    FILE_CONSTRUCTORS.update({ext.lower(): constructor for ext in extensions
-                              if ext not in FILE_CONSTRUCTORS})
+def _ensure_iterable(item):
+    """Ensure item is a non-string iterable (wrap in a list if not)"""
+    try:
+        len(item)
+        has_len = True
+    except TypeError:
+        has_len = False
+
+    if isinstance(item, str) or not has_len:
+        return [item]
+    return item
+
+
+def register_filetype(constructor, extensions=(), groups=(), datasets=()):
+    extensions = _ensure_iterable(extensions)
+    FILE_CONSTRUCTORS.update({
+        ext.lower(): constructor
+        for ext in _ensure_iterable(extensions)
+        if ext not in FILE_CONSTRUCTORS
+    })
+    GROUP_LIKE.extend(_ensure_iterable(groups))
+    DATASET_LIKE.extend(_ensure_iterable(datasets))
 
 
 # add hdf5 extensions if we have h5py
 try:
     import h5py
-    register_filetype(h5py.File, ".h5", ".hdf", ".hdf5")
+    register_filetype(h5py.File, [".h5", ".hdf", ".hdf5"], h5py.Group, h5py.Dataset)
 except ImportError:
     h5py = None
 
 # add n5 and zarr extensions if we have z5py
 try:
     import z5py
-    register_filetype(z5py.File, ".n5", ".zarr", ".zr")
+    register_filetype(z5py.File, N5_EXTS + ZARR_EXTS, z5py.Group, z5py.Dataset)
 except ImportError:
     z5py = None
 
-# TODO
-# - add zarr extensions if we have zarr-python as a backup to z5py
-
 # Are there any typical knossos extensions?
 # add knossos (no extension)
-register_filetype(KnossosFile, '')
+register_filetype(KnossosFile, '', KnossosFile, KnossosDataset)

--- a/elf/io/files.py
+++ b/elf/io/files.py
@@ -1,6 +1,8 @@
 import os
-from .extensions import FILE_CONSTRUCTORS, GROUP_LIKE, DATASET_LIKE
-from .extensions import h5py, z5py
+from .extensions import (
+    FILE_CONSTRUCTORS, GROUP_LIKE, DATASET_LIKE,
+    h5py, z5py, pyn5, zarr,
+)
 from .knossos_wrapper import KnossosFile, KnossosDataset
 
 
@@ -59,6 +61,14 @@ def is_h5py(node):
     """ Check if this is a h5py object
     """
     return h5py and isinstance(node, (h5py.Dataset, h5py.Group))
+
+
+def is_zarr(node):
+    return zarr and isinstance(node, (zarr.core.Array, zarr.hierarchy.Group))
+
+
+def is_pyn5(node):
+    return pyn5 and isinstance(node, (pyn5.Dataset, pyn5.Group))
 
 
 def is_knossos(node):

--- a/elf/io/files.py
+++ b/elf/io/files.py
@@ -1,5 +1,5 @@
 import os
-from .extensions import FILE_CONSTRUCTORS
+from .extensions import FILE_CONSTRUCTORS, GROUP_LIKE, DATASET_LIKE
 from .extensions import h5py, z5py
 from .knossos_wrapper import KnossosFile, KnossosDataset
 
@@ -27,10 +27,12 @@ def open_file(path, mode='a', ext=None):
     try:
         constructor = FILE_CONSTRUCTORS[ext.lower()]
     except KeyError:
-        raise ValueError("""Could not infer file type from extension %s,
-                          because it is not in the supported extensions: %s.
-                          You may need to install additional dependencies (h5py, z5py, zarr)."""
-                         % (ext, ' '.join(supported_extensions())))
+        raise ValueError(
+            f"Could not infer file type from extension {ext}, "
+            f"because it is not in the supported extensions: "
+            f"{' '.join(supported_extensions())}. "
+            f"You may need to install additional dependencies (h5py, z5py, zarr)."
+        )
     return constructor(path, mode=mode)
 
 
@@ -38,25 +40,13 @@ def open_file(path, mode='a', ext=None):
 def is_group(node):
     """ Check if argument is an h5py or z5py group
     """
-    if h5py and isinstance(node, h5py.Group):
-        return True
-    if z5py and isinstance(node, z5py.Group):
-        return True
-    if isinstance(node, KnossosFile):
-        return True
-    return False
+    return isinstance(node, tuple(GROUP_LIKE))
 
 
 def is_dataset(node):
     """ Check if argument is an h5py or z5py dataset
     """
-    if h5py and isinstance(node, h5py.Dataset):
-        return True
-    if z5py and isinstance(node, z5py.Dataset):
-        return True
-    if isinstance(node, KnossosDataset):
-        return True
-    return False
+    return isinstance(node, tuple(DATASET_LIKE))
 
 
 def is_z5py(node):

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,9 @@ requires = [
 extras = {
     "hdf5": ["h5py"],
     "zarr": ["zarr"],
-    # only available on conda, breaks pip install
-    "vigra": ["vigra"],
-    "nifty": ["nifty"],
-    # only available on PyPI, breaks conda install
-    # "n5": ["pyn5"],
+    "vigra": ["vigra"],  # conda-only
+    "nifty": ["nifty"],  # conda-only; name clash w/ different PyPI package
+    # "n5": ["pyn5"],  # PyPI-only
 }
 
 extras["all"] = list(itertools.chain.from_iterable(extras.values()))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import runpy
 import itertools
 from setuptools import setup, find_packages
 
-__version__ = runpy.run_path('elf/__version__.py')['__version__']
+__version__ = runpy.run_path("elf/__version__.py")["__version__"]
 
 requires = [
     "numpy",
@@ -11,25 +11,39 @@ requires = [
     "skan"
 ]
 
+
+# optional dependencies for setuptools
 extras = {
-    "hdf5": ["h5py"],
-    "zarr": ["zarr"],
-    "vigra": ["vigra"],  # conda-only
-    "nifty": ["nifty"],  # conda-only; name clash w/ different PyPI package
-    # "n5": ["pyn5"],  # PyPI-only
+    "hdf5": "h5py",
+    "zarr": "zarr",
+    "n5": "pyn5"
 }
 
-extras["all"] = list(itertools.chain.from_iterable(extras.values()))
+# dependencies only available via conda,
+# we still collect them here, because the conda recipe
+# gets it's requirements from setuptools.
+conda_only = ["vigra", "nifty", "z5py"]
+
+# collect all dependencies for conda
+conda_exclude = [
+    "zarr",  # we don't need zarr dependencies in conda, because we use z5py
+    "pyn5"  # pyn5 is not available on conda (and not needed due to z5py)
+]
+conda_all = conda_only + [v for v in extras.values() if v not in conda_exclude]
+extras["conda_all"] = conda_all
+
+# NOTE in case we want to support different conda flavors at some point, we
+# can add keys to 'extras', e.g. 'conda_no_hdf5' without h5py
 
 setup(
-    name='elf',
-    packages=find_packages(exclude=['test']),
+    name="elf",
+    packages=find_packages(exclude=["test"]),
     version=__version__,
-    author='Constantin Pape',
+    author="Constantin Pape",
     install_requires=requires,
     extras_require=extras,
-    url='https://github.com/constantinpape/elf',
-    license='MIT'
+    url="https://github.com/constantinpape/elf",
+    license="MIT"
     # we will probably have scripts at some point, so I am leaving this for reference
     # entry_points={
     #     "console_scripts": ["view_container = heimdall.scripts.view_container:main"]

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,11 @@ requires = [
 extras = {
     "hdf5": ["h5py"],
     "zarr": ["zarr"],
+    # only available on conda, breaks pip install
     "vigra": ["vigra"],
-    "nifty": ["nifty"]
+    "nifty": ["nifty"],
+    # only available on PyPI, breaks conda install
+    # "n5": ["pyn5"],
 }
 
 extras["all"] = list(itertools.chain.from_iterable(extras.values()))

--- a/test/io_tests/test_files.py
+++ b/test/io_tests/test_files.py
@@ -54,42 +54,42 @@ class FileTestMixin:
         self.assertFalse(is_group(ds))
 
 
-@unittest.skipIf(h5py is None, "Need h5py")
+@unittest.skipUnless(h5py, "Need h5py")
 class TestH5pyFiles(FileTestBase, FileTestMixin):
     ext = ".h5"
     constructor = getattr(h5py, "File", None)
 
 
-@unittest.skipIf(z5py is None, "Need z5py")
+@unittest.skipUnless(z5py, "Need z5py")
 class TestZ5pyN5Files(FileTestBase, FileTestMixin):
     ext = ".n5"
     constructor = getattr(z5py, "N5File", None)
 
 
-@unittest.skipIf(z5py is None, "Need z5py")
+@unittest.skipUnless(z5py, "Need z5py")
 class TestZ5pyZarrFiles(FileTestBase, FileTestMixin):
     ext = ".zr"
     constructor = getattr(z5py, "ZarrFile", None)
 
 
-@unittest.skipIf(pyn5 is None, "Need pyn5")
+@unittest.skipUnless(pyn5, "Need pyn5")
 class TestPyn5Files(FileTestBase, FileTestMixin):
     ext = ".n5"
     constructor = getattr(pyn5, "File", None)
 
 
-@unittest.skipIf(zarr is None, "Need zarr")
+@unittest.skipUnless(zarr, "Need zarr")
 class TestZarrFiles(FileTestBase, FileTestMixin):
     ext = ".zr"
     constructor = getattr(zarr, "open", None)
 
 
 class TestBackendPreference(unittest.TestCase):
-    @unittest.skipIf(z5py is None and zarr is None, "Need z5py and zarr")
+    @unittest.skipUnless(z5py and zarr, "Need z5py and zarr")
     def test_z5py_over_zarr(self):
         self.assertTrue(issubclass(FILE_CONSTRUCTORS[".n5"], z5py.File))
 
-    @unittest.skipIf(z5py is None and pyn5 is None, "Need z5py and pyn5")
+    @unittest.skipUnless(z5py and pyn5, "Need z5py and pyn5")
     def test_z5py_over_pyn5(self):
         self.assertTrue(issubclass(FILE_CONSTRUCTORS[".zr"], z5py.File))
 

--- a/test/io_tests/test_files.py
+++ b/test/io_tests/test_files.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from shutil import rmtree
 
 import numpy as np
-from elf.io.extensions import h5py, z5py, pyn5, zarr, FILE_CONSTRUCTORS
+from elf.io.extensions import h5py, z5py, pyn5, zarr, zarr_open, FILE_CONSTRUCTORS
 
 
 class FileTestBase(unittest.TestCase):
@@ -81,7 +81,7 @@ class TestPyn5Files(FileTestBase, FileTestMixin):
 @unittest.skipUnless(zarr, "Need zarr")
 class TestZarrFiles(FileTestBase, FileTestMixin):
     ext = ".zr"
-    constructor = getattr(zarr, "open", None)
+    constructor = staticmethod(zarr_open)
 
 
 class TestBackendPreference(unittest.TestCase):

--- a/test/io_tests/test_files.py
+++ b/test/io_tests/test_files.py
@@ -1,21 +1,22 @@
 import os
 import unittest
+from contextlib import contextmanager
+from unittest.mock import patch
 from shutil import rmtree
+
 import numpy as np
-
-try:
-    import h5py
-except ImportError:
-    h5py = None
-
-try:
-    import z5py
-except ImportError:
-    z5py = None
+from elf.io.extensions import h5py, z5py, pyn5, zarr
 
 
-class TestFiles(unittest.TestCase):
-    tmp_dir = './tmp'
+@contextmanager
+def patch_constructors(constructor, ext):
+    with patch("elf.io.extensions.FILE_CONSTRUCTORS", {ext: constructor}):
+        yield
+
+
+class FileTestBase(unittest.TestCase):
+    # todo: use https://github.com/clbarnes/tempcase/
+    tmp_dir = "./tmp"
 
     def setUp(self):
         os.makedirs(self.tmp_dir, exist_ok=True)
@@ -26,34 +27,32 @@ class TestFiles(unittest.TestCase):
         except OSError:
             pass
 
-    def _test_open(self, file_constructor, ext):
+    def path_to(self, *args):
+        return os.path.join("./tmp", *args)
+
+
+class FileTestMixin:
+    ext = None
+    constructor = None
+
+    def test_open(self):
         from elf.io import open_file
         shape = (128,) * 2
         data = np.random.rand(*shape)
-        fname = os.path.join(self.tmp_dir, 'data%s' % ext)
-        with file_constructor(fname, 'a') as f:
+        fname = self.path_to("data" + self.ext)
+        with self.constructor(fname, 'a') as f:
             f.create_dataset('data', data=data)
 
-        with open_file(fname) as f:
-            out = f['data'][:]
+        with patch("elf.io.extensions.FILE_CONSTRUCTORS", {self.ext: self.constructor}):
+            with open_file(fname) as f:
+                out = f['data'][:]
 
         self.assertEqual(data.shape, out.shape)
         self.assertTrue(np.allclose(data, out))
 
-    @unittest.skipIf(h5py is None, "Need h5py")
-    def test_open_h5(self):
-        self._test_open(h5py.File, '.h5')
-
-    @unittest.skipIf(z5py is None, "Need z5py")
-    def test_open_n5(self):
-        self._test_open(z5py.N5File, '.n5')
-
-    @unittest.skipIf(z5py is None, "Need z5py")
-    def test_open_zarr(self):
-        self._test_open(z5py.ZarrFile, '.zr')
-
-    def _test_is_group(self, f):
+    def test_is_group(self):
         from elf.io import is_group
+        f = self.constructor(self.path_to("data" + self.ext), mode="a")
         g = f.create_group('group')
         ds = f.create_dataset('dataset', data=np.ones((100, 100)),
                               chunks=(10, 10))
@@ -61,16 +60,38 @@ class TestFiles(unittest.TestCase):
         self.assertTrue(is_group(g))
         self.assertFalse(is_group(ds))
 
-    @unittest.skipIf(h5py is None, "Need h5py")
-    def test_is_group_h5py(self):
-        f = h5py.File(os.path.join(self.tmp_dir, 'data.h5'), 'a')
-        self._test_is_group(f)
 
-    @unittest.skipIf(z5py is None, "Need z5py")
-    def test_is_group_z5py(self):
-        f = z5py.File(os.path.join(self.tmp_dir, 'data.n5'), 'a')
-        self._test_is_group(f)
+@unittest.skipIf(h5py is None, "Need h5py")
+class TestH5pyFiles(FileTestBase, FileTestMixin):
+    ext = ".h5"
+    constructor = getattr(h5py, "File", None)
 
+
+@unittest.skipIf(z5py is None, "Need z5py")
+class TestZ5pyN5Files(FileTestBase, FileTestMixin):
+    ext = ".n5"
+    constructor = getattr(z5py, "N5File", None)
+
+
+@unittest.skipIf(z5py is None, "Need z5py")
+class TestZ5pyZarrFiles(FileTestBase, FileTestMixin):
+    ext = ".zr"
+    constructor = getattr(z5py, "ZarrFile", None)
+
+
+@unittest.skipIf(pyn5 is None, "Need pyn5")
+class TestPyn5Files(FileTestBase, FileTestMixin):
+    ext = ".n5"
+    constructor = getattr(pyn5, "File", None)
+
+
+@unittest.skipIf(zarr is None, "Need zarr")
+class TestZarrFiles(FileTestBase, FileTestMixin):
+    ext = ".zr"
+    constructor = getattr(zarr, "open", None)
+
+
+# todo: test loading N5 files using zarr-python
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Adds zarr and pyn5 (for cases where conda isn't available)
- Makes group/dataset checking more flexible by expanding `register_filetype`
- Reduces duplicated code in `io_tests` using inheritance of test classes
- Explicitly adds optional dependencies to travis environment, as they weren't being picked up before