### PR TITLE
Fix `multicut_decomposition()`

### DIFF
--- a/elf/segmentation/multicut.py
+++ b/elf/segmentation/multicut.py
@@ -296,7 +296,7 @@ def multicut_cgc(graph, costs, time_limit=None, warmstart=True, warmstart_kl=Tru
 
 
 def multicut_decomposition(graph, costs, time_limit=None,
-                           n_threads=1, internal_solver='kernighan-lin',
+                           internal_solver='kernighan-lin',
                            **kwargs):
     """ Solve multicut problem with decomposition solver.
 
@@ -307,7 +307,6 @@ def multicut_decomposition(graph, costs, time_limit=None,
         graph [nifty.graph] - graph of multicut problem
         costs [np.ndarray] - edge costs of multicut problem
         time_limit [float] - time limit for inference in seconds (default: None)
-        n_threads [int] - number of threads (default: 1)
         internal_solver [str] - name of solver used for connected components
             (default: 'kernighan-lin')
     """
@@ -315,8 +314,7 @@ def multicut_decomposition(graph, costs, time_limit=None,
     solver_factory = _get_solver_factory(objective, internal_solver)
     solver = objective.multicutDecomposerFactory(
         submodelFactory=solver_factory,
-        fallthroughFactory=solver_factory,
-        numberOfThreads=n_threads
+        fallthroughFactory=solver_factory
     ).create(objective)
     visitor = _get_visitor(objective, time_limit, **kwargs)
     return solver.optimize() if visitor is None else solver.optimize(visitor=visitor)


### PR DESCRIPTION
Attempt to fix #34 

Remove number of threads for `multicut_decomposition()` because there is no implementation in `multicutDecomposerFactory()` in `nifty`:
```python
def multicutDecomposerFactory(submodelFactory=None, fallthroughFactory=None):    <----- only takes two args

    if submodelFactory is None:
       submodelFactory = MulticutObjectiveUndirectedGraph.defaultMulticutFactory()

    if fallthroughFactory is None:
        fallthroughFactory = O.defaultMulticutFactory()

    s,F = getSettingsAndFactoryCls("MulticutDecomposer")
    s.submodelFactory = submodelFactory
    s.fallthroughFactory = fallthroughFactory
    return F(s)

O.multicutDecomposerFactory = staticmethod(multicutDecomposerFactory)
O.multicutDecomposerFactory.__doc__ = """ create an instance of :class:`%s`
    This solver tries to decompose the model into
    sub-models  as described in :cite:`alush_2013_simbad`.
    If a model decomposes into components such that there are no
    positive weighted edges between the components one can
    optimize each model separately.
Note:
    Models might not decompose at all.
Args:
    submodelFactory: multicut factory for solving subproblems
        if model decomposes (default: {:func:`defaultMulticutFactory()`})
    fallthroughFactory: multicut factory for solving subproblems
        if model does not decompose (default: {:func:`defaultMulticutFactory()`})
Returns:
    %s : multicut factory
"""%(factoryClsName("MulticutDecomposer"),factoryClsName("MulticutDecomposer"))
```