### PR TITLE
RAMA changes

### DIFF
--- a/elf/segmentation/multicut.py
+++ b/elf/segmentation/multicut.py
@@ -411,10 +411,10 @@ def multicut_rama(graph, costs, time_limit=None, mode=None, **kwargs):
     if mode is None:
         opts = rama_py.multicut_solver_options()
     else:
-        assert mode in ("P", "PD+", "D")
+        assert mode in ("P", "PD", "PD+", "D")
         opts = rama_py.multicut_solver_options(mode)
     node_labels = rama_py.rama_cuda(
-        uv_ids[:, 0].tolist(), uv_ids[:, 1].tolist(), costs.tolist(), opts
+        uv_ids[:, 0], uv_ids[:, 1], costs, opts
     )[0]
     assert len(node_labels) == graph.numberOfNodes, f"{len(node_labels)}, {graph.numberOfNodes}"
     return node_labels

--- a/example/multicut/performance/pixelwise_experiments.py
+++ b/example/multicut/performance/pixelwise_experiments.py
@@ -63,7 +63,7 @@ def pixelwise_performance_experiments(solvers):
 def main():
     parser = argparse.ArgumentParser()
 
-    default_solvers = ["mutex-watershed", "greedy-additive", "rama_P", "rama_PD+"]
+    default_solvers = ["mutex-watershed", "greedy-additive", "rama_P", "rama_PD"]
     parser.add_argument("--solvers", "-s", default=default_solvers)
 
     args = parser.parse_args()


### PR DESCRIPTION
- Added default RAMA solver type (PD).
- Removed conversion to list for RAMA.
- Changed from PD+ solver in pixelwise_experiments to PD. (PD+ does not scale well for larger problems with larger average node degree). 

Pixelwise results after the above changes (and updating RAMA package):
  "greedy-additive": [-11328441, 403],
  "mutex-watershed": [-11119804, 7],
  "rama_P": [-12179768, 8],
  "rama_PD": [-12732112, 11]