### PR TITLE
Update mrc_wrapper.py

### DIFF
--- a/elf/io/mrc_wrapper.py
+++ b/elf/io/mrc_wrapper.py
@@ -55,9 +55,9 @@ class MRCFile(Mapping):
         if mrcfile is None:
             raise AttributeError("mrcfile is not available")
         try:
-            self._f = mrcfile.mmap(self.path, self.mode)
+            self._f = mrcfile.mmap(self.path, self.mode, permissive='True')
         except ValueError:
-            self._f = mrcfile.open(self.path, self.mode)
+            self._f = mrcfile.open(self.path, self.mode, permissive='True')
 
     def __getitem__(self, key):
         if key != 'data':

--- a/elf/io/mrc_wrapper.py
+++ b/elf/io/mrc_wrapper.py
@@ -59,7 +59,7 @@ class MRCFile(Mapping):
         except ValueError as e:
         
             # check if error comes from old version of SerialEM used for acquisition
-            if "Unrecognised machine stamp: 0x44 0x00 0x00 0x00" in e:
+            if "Unrecognised machine stamp: 0x44 0x00 0x00 0x00" in str(e):
                 try:
                     self._f = mrcfile.mmap(self.path, self.mode, permissive='True')
                 except ValueError:

--- a/elf/io/mrc_wrapper.py
+++ b/elf/io/mrc_wrapper.py
@@ -55,9 +55,18 @@ class MRCFile(Mapping):
         if mrcfile is None:
             raise AttributeError("mrcfile is not available")
         try:
-            self._f = mrcfile.mmap(self.path, self.mode, permissive='True')
-        except ValueError:
-            self._f = mrcfile.open(self.path, self.mode, permissive='True')
+            self._f = mrcfile.mmap(self.path, self.mode)
+        except ValueError as e:
+        
+            # check if error comes from old version of SerialEM used for acquisition
+            if "Unrecognised machine stamp: 0x44 0x00 0x00 0x00" in e:
+                try:
+                    self._f = mrcfile.mmap(self.path, self.mode, permissive='True')
+                except ValueError:
+                    self._f = mrcfile.open(self.path, self.mode, permissive='True')
+            else:
+                self._f = mrcfile.open(self.path, self.mode)
+               
 
     def __getitem__(self, key):
         if key != 'data':

--- a/test/io_tests/test_mrc_wrapper.py
+++ b/test/io_tests/test_mrc_wrapper.py
@@ -77,7 +77,9 @@ class TestMrcWrapper(unittest.TestCase):
         a.close()
 
         with self.assertRaises(ValueError):
-            b = mrcfile.open(self.out_old)
+            from elf.io.mrc_wrapper import MRCFile
+            with MRCFile(self.out_old) as f:
+                ds = f['data']
 
         os.remove(self.out_old)
 

--- a/test/io_tests/test_mrc_wrapper.py
+++ b/test/io_tests/test_mrc_wrapper.py
@@ -85,7 +85,7 @@ class TestMrcWrapper(unittest.TestCase):
 
         a = mrcfile.open(self.out_old, 'w+')
         a.header.machst = [68, 0, 0, 0]
-        a.data = self.data
+        a.set_data(self.data)
         a.close()
 
         with self.assertRaises(RuntimeWarning):

--- a/test/io_tests/test_mrc_wrapper.py
+++ b/test/io_tests/test_mrc_wrapper.py
@@ -3,6 +3,7 @@ import unittest
 from shutil import rmtree
 
 import numpy as np
+
 try:
     import mrcfile
 except ImportError:
@@ -24,13 +25,13 @@ class TestMrcWrapper(unittest.TestCase):
         # change axes order to fit MRC convention
         data0 = np.swapaxes(self.data, 0, -1)
         data1 = np.fliplr(data0)
-        out_data = np.swapaxes(data1, 0, -1)
+        self.out_data = np.swapaxes(data1, 0, -1)
 
         with mrcfile.new(self.out) as f:
-            f.set_data(out_data)
+            f.set_data(self.out_data)
 
         with mrcfile.new(self.out_compressed, compression='gzip') as f:
-            f.set_data(out_data)
+            f.set_data(self.out_data)
 
     def tearDown(self):
         rmtree(self.tmp_dir)
@@ -79,20 +80,20 @@ class TestMrcWrapper(unittest.TestCase):
         with self.assertRaises(ValueError):
             from elf.io.mrc_wrapper import MRCFile
             with MRCFile(self.out_old) as f:
-                ds = f['data']
+                __ = f['data']
 
         os.remove(self.out_old)
 
         a = mrcfile.open(self.out_old, 'w+')
         a.header.machst = [68, 0, 0, 0]
-        a.set_data(self.data)
+        a.set_data(self.out_data)
         a.close()
 
-        with self.assertRaises(RuntimeWarning):
-            from elf.io.mrc_wrapper import MRCFile
-            with MRCFile(self.out_old) as f:
-                ds = f['data']
-                self.check_dataset(ds)
+        from elf.io.mrc_wrapper import MRCFile
+        with MRCFile(self.out_old) as f:
+            ds = f['data']
+            self.check_dataset(ds)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/io_tests/test_mrc_wrapper.py
+++ b/test/io_tests/test_mrc_wrapper.py
@@ -13,6 +13,7 @@ except ImportError:
 class TestMrcWrapper(unittest.TestCase):
     tmp_dir = './tmp'
     out = './tmp/data.mrc'
+    out_old = './tmp/data_old.mrc'
     out_compressed = './tmp/data_compressed.mrc'
 
     def setUp(self):
@@ -70,6 +71,26 @@ class TestMrcWrapper(unittest.TestCase):
             ds = f['data']
             self.check_dataset(ds)
 
+    def test_old_serialem(self):
+        a = mrcfile.open(self.out_old, 'w+')
+        a.header.machst = [11, 0, 0, 0]
+        a.close()
+
+        with self.assertRaises(ValueError):
+            b = mrcfile.open(self.out_old)
+
+        os.remove(self.out_old)
+
+        a = mrcfile.open(self.out_old, 'w+')
+        a.header.machst = [68, 0, 0, 0]
+        a.data = self.data
+        a.close()
+
+        with self.assertRaises(RuntimeWarning):
+            from elf.io.mrc_wrapper import MRCFile
+            with MRCFile(self.out_old) as f:
+                ds = f['data']
+                self.check_dataset(ds)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
add the `permissive='True'` parameter to `mrcfile` to avoid crashing when issuing 
```
ValueError: Unrecognised machine stamp: 0x44 0x00 0x00 0x00
```
resulting from MRC files generated with older versions of SerialEM.

see https://github.com/ccpem/mrcfile/issues/4