### PR TITLE
Use threadctl to set numpy thread limits in scope

### DIFF
--- a/elf/parallel/relabel.py
+++ b/elf/parallel/relabel.py
@@ -1,4 +1,8 @@
+# IMPORTANT do threadctl import first (before numpy imports)
+from threadpoolctl import threadpool_limits
+
 import multiprocessing
+
 # would be nice to use dask, so that we can also run this on the cluster
 from concurrent import futures
 from tqdm import tqdm
@@ -6,8 +10,7 @@ import nifty.tools as nt
 
 from .unique import unique
 from .common import get_blocking
-from ..util import set_numpy_threads
-set_numpy_threads(1)
+
 import numpy as np
 
 
@@ -51,6 +54,7 @@ def relabel_consecutive(data, start_label=0, keep_zeros=True, out=None,
         raise ValueError("Expect data and out of same shape, got %s and %s" % (str(data.shape),
                                                                                str(out.shape)))
 
+    @threadpool_limits.wrap(limits=1)  # restrict the numpy threadpool to 1 to avoid oversubscription
     def _relabel(block_id):
         block = blocking.getBlock(block_id)
         bb = tuple(slice(beg, end) for beg, end in zip(block.begin, block.end))

--- a/elf/parallel/stats.py
+++ b/elf/parallel/stats.py
@@ -1,3 +1,6 @@
+# IMPORTANT do threadctl import first (before numpy imports)
+from threadpoolctl import threadpool_limits
+
 import multiprocessing
 # would be nice to use dask for all of this instead of concurrent.futures
 # so that this could be used on a cluster as well
@@ -5,8 +8,7 @@ from concurrent import futures
 from tqdm import tqdm
 
 from .common import get_blocking
-from ..util import set_numpy_threads
-set_numpy_threads(1)
+
 import numpy as np
 
 
@@ -29,6 +31,7 @@ def mean(data, block_shape=None, n_threads=None, mask=None, verbose=False, roi=N
     blocking = get_blocking(data, block_shape, roi)
     n_blocks = blocking.numberOfBlocks
 
+    @threadpool_limits.wrap(limits=1)  # restrict the numpy threadpool to 1 to avoid oversubscription
     def _mean(block_id):
         block = blocking.getBlock(block_id)
         bb = tuple(slice(beg, end) for beg, end in zip(block.begin, block.end))
@@ -77,6 +80,7 @@ def mean_and_std(data, block_shape=None, n_threads=None, mask=None, verbose=Fals
     blocking = get_blocking(data, block_shape, roi)
     n_blocks = blocking.numberOfBlocks
 
+    @threadpool_limits.wrap(limits=1)  # restrict the numpy threadpool to 1 to avoid oversubscription
     def _mean_and_std(block_id):
         block = blocking.getBlock(block_id)
         bb = tuple(slice(beg, end) for beg, end in zip(block.begin, block.end))
@@ -150,6 +154,7 @@ def min_and_max(data, block_shape=None, n_threads=None, mask=None, verbose=False
     blocking = get_blocking(data, block_shape, roi)
     n_blocks = blocking.numberOfBlocks
 
+    @threadpool_limits.wrap(limits=1)  # restrict the numpy threadpool to 1 to avoid oversubscription
     def _min_and_max(block_id):
         block = blocking.getBlock(block_id)
         bb = tuple(slice(beg, end) for beg, end in zip(block.begin, block.end))

--- a/elf/parallel/unique.py
+++ b/elf/parallel/unique.py
@@ -1,11 +1,13 @@
+# IMPORTANT do threadctl import first (before numpy imports)
+from threadpoolctl import threadpool_limits
+
 import multiprocessing
 # would be nice to use dask, so that we can also run this on the cluster
 from concurrent import futures
 from tqdm import tqdm
 
 from .common import get_blocking
-from ..util import set_numpy_threads
-set_numpy_threads(1)
+
 import numpy as np
 
 
@@ -31,6 +33,7 @@ def unique(data, return_counts=False, block_shape=None, n_threads=None,
     blocking = get_blocking(data, block_shape, roi)
     n_blocks = blocking.numberOfBlocks
 
+    @threadpool_limits.wrap(limits=1)  # restrict the numpy threadpool to 1 to avoid oversubscription
     def _unique(block_id):
         block = blocking.getBlock(block_id)
         bb = tuple(slice(beg, end) for beg, end in zip(block.begin, block.end))

--- a/elf/util.py
+++ b/elf/util.py
@@ -1,6 +1,4 @@
-import ctypes
 import numbers
-import os
 from math import ceil
 from itertools import product
 
@@ -9,7 +7,7 @@ def slice_to_start_stop(s, size):
     """For a single dimension with a given size, normalize slice to size.
      Returns slice(None, 0) if slice is invalid."""
     if s.step not in (None, 1):
-        raise ValueError('Nontrivial steps are not supported')
+        raise ValueError("Nontrivial steps are not supported")
 
     if s.start is None:
         start = 0
@@ -39,7 +37,7 @@ def int_to_start_stop(i, size):
     if -size < i < 0:
         start = i + size
     elif i >= size or i < -size:
-        raise ValueError('Index ({}) out of range (0-{})'.format(i, size - 1))
+        raise ValueError("Index ({}) out of range (0-{})".format(i, size - 1))
     else:
         start = i
     return slice(start, start + 1)
@@ -47,7 +45,7 @@ def int_to_start_stop(i, size):
 
 # For now, I have copied the z5 implementation:
 # https://github.com/constantinpape/z5/blob/master/src/python/module/z5py/shape_utils.py#L126
-# But it's worth taking a look at @clbarnes more general implementation too
+# But it"s worth taking a look at @clbarnes more general implementation too
 # https://github.com/clbarnes/h5py_like
 def normalize_index(index, shape):
     """ Normalize index to shape.
@@ -62,8 +60,8 @@ def normalize_index(index, shape):
         tuple[slice]: normalized slices (start and stop are both non-None)
         tuple[int]: which singleton dimensions should be squeezed out
     """
-    type_msg = 'Advanced selection inappropriate. ' \
-               'Only numbers, slices (`:`), and ellipsis (`...`) are valid indices (or tuples thereof)'
+    type_msg = "Advanced selection inappropriate. " \
+               "Only numbers, slices (`:`), and ellipsis (`...`) are valid indices (or tuples thereof)"
 
     if isinstance(index, tuple):
         slices_lst = list(index)
@@ -201,37 +199,6 @@ def downscale_shape(shape, scale_factor, ceil_mode=True):
                      for sh, sf in zip(shape, scale_))
     else:
         return tuple(sh // sf for sh, sf in zip(shape, scale_))
-
-
-def set_numpy_threads(n_threads):
-    """ Set the number of threads numpy exposes to its
-    underlying linalg library.
-
-    This needs to be called BEFORE the numpy import and sets the number
-    of threads statically.
-    Based on answers in https://github.com/numpy/numpy/issues/11826.
-    """
-
-    # set number of threads for mkl if it is used
-    try:
-        import mkl
-        mkl.set_num_threaads(n_threads)
-    except Exception:
-        pass
-
-    for name in ['libmkl_rt.so', 'libmkl_rt.dylib', 'mkl_Rt.dll']:
-        try:
-            mkl_rt = ctypes.CDLL(name)
-            mkl_rt.mkl_set_num_threads(ctypes.byref(ctypes.c_int(n_threads)))
-        except Exception:
-            pass
-
-    # set number of threads in all possibly relevant environment variables
-    os.environ['OMP_NUM_THREADS'] = str(n_threads)
-    os.environ['OPENBLAS_NUM_THREADS'] = str(n_threads)
-    os.environ['MKL_NUM_THREADS'] = str(n_threads)
-    os.environ['VECLIB_NUM_THREADS'] = str(n_threads)
-    os.environ['NUMEXPR_NUM_THREADS'] = str(n_threads)
 
 
 def sigma_to_halo(sigma, order):

--- a/example/parallel/check_threadctrl.py
+++ b/example/parallel/check_threadctrl.py
@@ -1,0 +1,68 @@
+
+
+def check_normal():
+    import time
+    import numpy as np
+
+    x = np.random.rand(2048, 2048)
+    N = 10
+
+    ts = []
+    print("Start")
+    for _ in range(N):
+        t0 = time.time()
+        x @ x
+        ts.append(time.time() - t0)
+    print(min(ts))
+
+
+def check_numpy_threads():
+    from elf.util import set_numpy_threads
+    set_numpy_threads(1)
+    import time
+    import numpy as np
+
+    x = np.random.rand(2048, 2048)
+    N = 10
+
+    ts = []
+    print("Start")
+    for _ in range(N):
+        t0 = time.time()
+        x @ x
+        ts.append(time.time() - t0)
+    print(min(ts))
+
+
+def check_threadctrl():
+    import time
+    from threadpoolctl import threadpool_limits
+    import numpy as np
+
+    x = np.random.rand(2048, 2048)
+    N = 10
+
+    ts = []
+    print("Start")
+    with threadpool_limits(limits=1):
+        for _ in range(N):
+            t0 = time.time()
+            x @ x
+            ts.append(time.time() - t0)
+    print(min(ts))
+
+
+def main():
+    # time: 0.11289644241333008
+    # check_normal()
+
+    # time: 0.4072251319885254
+    # check_numpy_threads()
+
+    # It works!
+    # time: 0.4088623523712158
+    check_threadctrl()
+
+
+if __name__ == "__main__":
+    main()

--- a/example/parallel/check_threadctrl.py
+++ b/example/parallel/check_threadctrl.py
@@ -1,3 +1,37 @@
+import os
+import ctypes
+
+
+def set_numpy_threads(n_threads):
+    """ Set the number of threads numpy exposes to its underlying linalg library.
+
+    This is now deprecated in favor of threadctl and was moved here from elf.util.
+
+    This needs to be called BEFORE the numpy import and sets the number
+    of threads statically.
+    Based on answers in https://github.com/numpy/numpy/issues/11826.
+    """
+
+    # set number of threads for mkl if it is used
+    try:
+        import mkl
+        mkl.set_num_threaads(n_threads)
+    except Exception:
+        pass
+
+    for name in ["libmkl_rt.so", "libmkl_rt.dylib", "mkl_Rt.dll"]:
+        try:
+            mkl_rt = ctypes.CDLL(name)
+            mkl_rt.mkl_set_num_threads(ctypes.byref(ctypes.c_int(n_threads)))
+        except Exception:
+            pass
+
+    # set number of threads in all possibly relevant environment variables
+    os.environ["OMP_NUM_THREADS"] = str(n_threads)
+    os.environ["OPENBLAS_NUM_THREADS"] = str(n_threads)
+    os.environ["MKL_NUM_THREADS"] = str(n_threads)
+    os.environ["VECLIB_NUM_THREADS"] = str(n_threads)
+    os.environ["NUMEXPR_NUM_THREADS"] = str(n_threads)
 
 
 def check_normal():
@@ -17,7 +51,6 @@ def check_normal():
 
 
 def check_numpy_threads():
-    from elf.util import set_numpy_threads
     set_numpy_threads(1)
     import time
     import numpy as np


### PR DESCRIPTION
rather than using global scope via the `set_numpy_threads` function.

Fixes #75. 