### PR TITLE
enable slicing stacks in arbitrary dimensions

### DIFF
--- a/elf/io/image_stack_wrapper.py
+++ b/elf/io/image_stack_wrapper.py
@@ -118,6 +118,7 @@ class ImageStackDataset:
         self.im_shape, dtype = self.get_im_shape_and_dtype(files)
 
         self._shape = (n_slices,) + self.im_shape
+        self._slicing = None
         self._chunks = (1,) + self.im_shape
         self._dtype = dtype
         self._size = np.prod(list(self._shape))

--- a/elf/io/image_stack_wrapper.py
+++ b/elf/io/image_stack_wrapper.py
@@ -125,10 +125,11 @@ class ImageStackDataset:
 
     def initialize_from_stack(self, files):
         self.files = files
+        self._slicing = None
+
         self._volume = self._read_volume()
 
         self._shape = self._volume.shape
-        self._slicing = None
         # chunks are arbitrary
         self._chunks = None
         self._dtype = self._volume.dtype


### PR DESCRIPTION
Hi, this should enable extracting only sub-dimensional parts of stacks. (-> single channels of multi-channel stacks for MoBIE etc...)

I have not checked how it can be tested yet, but the actual slicing happens in `cluster_tools`, so it might be more interesting to test there...

https://github.com/constantinpape/cluster_tools/pull/42

