### PR TITLE
Use zarr over z5py

### DIFF
--- a/elf/io/extensions.py
+++ b/elf/io/extensions.py
@@ -35,12 +35,12 @@ def _ensure_iterable(item):
     return item
 
 
-def register_filetype(constructor, extensions=(), groups=(), datasets=()):
+def register_filetype(constructor, extensions=(), groups=(), datasets=(), overwrite=False):
     extensions = _ensure_iterable(extensions)
     FILE_CONSTRUCTORS.update({
         ext.lower(): constructor
         for ext in _ensure_iterable(extensions)
-        if ext not in FILE_CONSTRUCTORS
+        if ext not in FILE_CONSTRUCTORS or overwrite
     })
     GROUP_LIKE.extend(_ensure_iterable(groups))
     DATASET_LIKE.extend(_ensure_iterable(datasets))
@@ -115,7 +115,7 @@ try:
         return z
 
     register_filetype(
-        zarr_open, N5_EXTS + ZARR_EXTS, zarr.hierarchy.Group, zarr.core.Array
+        zarr_open, N5_EXTS + ZARR_EXTS, zarr.hierarchy.Group, zarr.core.Array, True
     )
 except ImportError:
     zarr = None

--- a/test/io_tests/test_files.py
+++ b/test/io_tests/test_files.py
@@ -87,8 +87,8 @@ class TestZarrFiles(FileTestBase, FileTestMixin):
 
 class TestBackendPreference(unittest.TestCase):
     @unittest.skipUnless(z5py and zarr, "Need z5py and zarr")
-    def test_z5py_over_zarr(self):
-        self.assertTrue(issubclass(FILE_CONSTRUCTORS[".n5"], z5py.File))
+    def test_zarr_over_z5py(self):
+        self.assertTrue(FILE_CONSTRUCTORS[".n5"] == zarr_open)
 
     @unittest.skipUnless(z5py and pyn5, "Need z5py and pyn5")
     def test_z5py_over_pyn5(self):

--- a/test/transformation/test_affine.py
+++ b/test/transformation/test_affine.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.ndimage import affine_transform
 from elf.io import open_file
 from elf.util import normalize_index
+import z5py
 
 
 class TestAffine(unittest.TestCase):
@@ -29,7 +30,7 @@ class TestAffine(unittest.TestCase):
         if out_file is not None:
             with open_file(out_file) as f:
                 x = f.create_dataset('tmp', data=x, chunks=(64, 64))
-            f = open_file(out_file, 'r')
+            f = z5py.File(out_file, 'r')
             x = f['tmp']
 
         bbs = [np.s_[:, :], np.s_[:256, :256], np.s_[37:115, 226:503],

--- a/test/transformation/test_affine.py
+++ b/test/transformation/test_affine.py
@@ -90,7 +90,7 @@ class TestAffine(unittest.TestCase):
         if out_file is not None:
             with open_file(out_file) as f:
                 x = f.create_dataset('tmp', data=x, chunks=3 * (16,))
-            f = open_file(out_file, 'r')
+            f = z5py.File(out_file, 'r')
             x = f['tmp']
 
         bbs = [np.s_[:, :, :], np.s_[:32, :32, :32], np.s_[1:31, 5:27, 3:13],


### PR DESCRIPTION
Related to https://github.com/constantinpape/z5/issues/196

z5py can't open zarr files with big-endian dtype. Use zarr package insead. Added overwrite flag to allow this.