### PR TITLE
Make `ImageStackDataset` flexible for loading RGB slices

### DIFF
--- a/elf/io/image_stack_wrapper.py
+++ b/elf/io/image_stack_wrapper.py
@@ -96,7 +96,6 @@ class ImageStackDataset:
         """@private
         """
         im0 = imageio.imread(files[0])
-        assert im0.ndim == 2
         return im0.shape, im0.dtype
 
     def initialize_from_slices(self, files, sort_files=True):


### PR DESCRIPTION
This PR makes image stack dataset flexible for loading RGB slices as a stack, as long as all dimensions agree with matching the expected shape. GTG from my side!

cc: @constantinpape 