### PR TITLE
Make zarr2 a soft constraint

### DIFF
--- a/elf/io/extensions.py
+++ b/elf/io/extensions.py
@@ -116,8 +116,7 @@ def noop(*args, **kwargs):
 try:
     # will not override z5py
     import zarr
-    from packaging.version import Version
-    if Version(zarr.__version__) >= Version("3.0.0"):
+    if int(zarr.__version__.split('.', maxsplit=1)[0]) > 2:
         raise ImportError(
             f"zarr {zarr.__version__} (>=3.0.0) is not supported. "
             "Please downgrade to zarr 2 if you require zarr support. "
@@ -143,7 +142,7 @@ try:
     register_filetype(
         zarr_open, N5_EXTS + ZARR_EXTS, zarr.hierarchy.Group, zarr.core.Array, True
     )
-except ImportError:
+except Exception:
     zarr = None
     zarr_open = None
 

--- a/elf/io/extensions.py
+++ b/elf/io/extensions.py
@@ -116,6 +116,14 @@ def noop(*args, **kwargs):
 try:
     # will not override z5py
     import zarr
+    from packaging.version import Version
+    if Version(zarr.__version__) >= Version("3.0.0"):
+        raise ImportError(
+            f"zarr {zarr.__version__} (>=3.0.0) is not supported. "
+            "Please downgrade to zarr 2 if you require zarr support. "
+            "See https://github.com/constantinpape/elf/issues/114 "
+            "for more details."
+        )
 
     # zarr stores cannot be used as context managers,
     # which breaks compatibility with similar libraries.


### PR DESCRIPTION
My general goal is to enable numpy 2.

Zarr2 -> zarr3 is an annoyance, but I don't think zarr is too widely used.

Could we drop this to being fully optional, rather than being mandatory?

micro_sam -> python-elf -> zarr2

Feel free to close or let me know how you might edit how this feature is communicated to the end user.