### PR TITLE
Update zarr tests for maintaining v2 compatibility

### DIFF
--- a/elf/io/zarr_wrapper.py
+++ b/elf/io/zarr_wrapper.py
@@ -1,14 +1,10 @@
 from numbers import Number
-from packaging import version
 from typing import Optional, Union, Tuple
 
 import numpy as np
+import zarr
 from numpy.typing import ArrayLike
 
-import zarr
-
-
-ZARR_V3 = version.parse(zarr.__version__) >= version.parse("3.0.0")
 SUPPORTED_CODECS = ("blosc", "gzip", "zstd")
 """Supported compression codecs
 """
@@ -20,8 +16,8 @@ def _check_consistency(data, dtype, shape):
         if dtype is None:
             raise ValueError("You have to pass a dtype if data is not passed.")
 
-        if shape is None and not ZARR_V3:
-            raise ValueError("In Zarr v2, 'shape' must be provided if 'data' is None. In Zarr v3, this is optional.")
+        if shape is None:
+            raise ValueError("You have to pass the shape if data is not passed.")
 
     # Data was passed. dtype and shape are not required.
     # If given, we check that they are consistent, otherwise we derive them from the data.

--- a/elf/io/zarr_wrapper.py
+++ b/elf/io/zarr_wrapper.py
@@ -1,10 +1,14 @@
 from numbers import Number
+from packaging import version
 from typing import Optional, Union, Tuple
 
 import numpy as np
-import zarr
 from numpy.typing import ArrayLike
 
+import zarr
+
+
+ZARR_V3 = version.parse(zarr.__version__) >= version.parse("3.0.0")
 SUPPORTED_CODECS = ("blosc", "gzip", "zstd")
 """Supported compression codecs
 """
@@ -16,8 +20,8 @@ def _check_consistency(data, dtype, shape):
         if dtype is None:
             raise ValueError("You have to pass a dtype if data is not passed.")
 
-        if shape is None:
-            raise ValueError("You have to pass the shape if data is not passed.")
+        if shape is None and not ZARR_V3:
+            raise ValueError("In Zarr v2, 'shape' must be provided if 'data' is None. In Zarr v3, this is optional.")
 
     # Data was passed. dtype and shape are not required.
     # If given, we check that they are consistent, otherwise we derive them from the data.

--- a/test/io_tests/test_zarr_wrapper.py
+++ b/test/io_tests/test_zarr_wrapper.py
@@ -63,7 +63,7 @@ class ZarrWrapperTest(unittest.TestCase):
         for i, codec in enumerate(SUPPORTED_CODECS, 4):
             ds_name = f"{prefix}-{i}"
             if zarr_major_version == 2:
-                ds = method(ds_name, data=test_data, shape=test_data.shape, chunks=chunks, compression=codec)
+                ds = method(ds_name, data=test_data, shape=shape, chunks=chunks, compression=codec)
             else:
                 ds = method(ds_name, data=test_data, chunks=chunks, compression=codec)
 


### PR DESCRIPTION
This PR takes care of keeping the tests modular for zarr v2 and v3 (to take care of the report at https://github.com/conda-forge/python-elf-feedstock/pull/23#issuecomment-2870190956)

cc: @constantinpape 