### PR TITLE
Start implementation of msr file wrapper

### DIFF
--- a/elf/io/__init__.py
+++ b/elf/io/__init__.py
@@ -4,4 +4,4 @@
 from .files import open_file, supported_extensions
 from .files import is_group, is_dataset, is_h5py, is_z5py, is_knossos
 
-from .msr_wrapper import MSRDataset, MSRFile
+from .msr_wrapper import MSRDataset, MSRFile, MSRSampleCollection

--- a/elf/io/__init__.py
+++ b/elf/io/__init__.py
@@ -3,3 +3,5 @@
 
 from .files import open_file, supported_extensions
 from .files import is_group, is_dataset, is_h5py, is_z5py, is_knossos
+
+from .msr_wrapper import MSRDataset, MSRFile

--- a/elf/io/extensions.py
+++ b/elf/io/extensions.py
@@ -5,6 +5,7 @@ import numpy as np
 from .image_stack_wrapper import ImageStackFile, ImageStackDataset
 from .knossos_wrapper import KnossosFile, KnossosDataset
 from .mrc_wrapper import MRCFile, MRCDataset
+from .msr_wrapper import MSRFile, MSRDataset
 from .nifti_wrapper import NiftiFile, NiftiDataset
 from .intern_wrapper import InternFile, InternDataset
 
@@ -92,6 +93,14 @@ try:
     register_filetype(InternFile, ["bossdb://"], InternFile, InternDataset)
 except ImportError:
     intern = None
+
+
+# add msr extensions if we have msr-reader
+try:
+    import msr_reader
+    register_filetype(MSRFile, [".msr"], MSRFile, MSRDataset)
+except ImportError:
+    msr_reader = None
 
 # add nifti extensions if we have nibabel
 try:

--- a/elf/io/msr_wrapper.py
+++ b/elf/io/msr_wrapper.py
@@ -1,0 +1,268 @@
+import os
+from collections.abc import Mapping, Sequence
+from typing import Union
+
+import numpy as np
+
+from ..util import normalize_index, squeeze_singletons
+
+try:
+    from msr_reader import OBFFile
+except ImportError:
+    OBFFile = None
+
+
+_MSR_READER_INSTALL_ERROR = (
+    "msr_reader is required for MSR images, but is not installed. Install it with `pip install msr-reader`."
+)
+
+StackIndexSelection = Union[int, Sequence[int]]
+StackNameSelection = Union[str, Sequence[str]]
+StackSelection = Union[int, str, Sequence[Union[int, str]]]
+PathLike = Union[os.PathLike, str]
+
+
+def _require_msr_reader():
+    if OBFFile is None:
+        raise AttributeError(_MSR_READER_INSTALL_ERROR)
+
+
+def _read_msr_stack(msr_path: PathLike, stack_index: int = 0) -> np.ndarray:
+    _require_msr_reader()
+    msr_path = os.fspath(msr_path)
+    with OBFFile(msr_path) as msr:
+        if stack_index < 0 or stack_index >= msr.num_stacks:
+            raise IndexError(
+                f"Invalid stack index {stack_index} for {msr_path}; available stacks: 0..{msr.num_stacks - 1}"
+            )
+        image = msr.read_stack(stack_index)
+    if image.ndim != 2:
+        raise ValueError(f"Expected a 2D MSR stack from {msr_path}, got shape {image.shape}")
+    return image
+
+
+def _normalize_stack_selection(stack_selection: StackSelection) -> tuple[Union[int, str], ...]:
+    if isinstance(stack_selection, (str, int)):
+        return (stack_selection,)
+    stack_selection = tuple(stack_selection)
+    if not stack_selection:
+        raise ValueError("At least one MSR stack index is required")
+    return stack_selection
+
+
+def _normalize_stack_indices(stack_index: StackIndexSelection = 0) -> tuple[int, ...]:
+    if isinstance(stack_index, int):
+        return (stack_index,)
+    stack_index = tuple(stack_index)
+    if not stack_index:
+        raise ValueError("At least one MSR stack index is required")
+    if any(not isinstance(index, int) for index in stack_index):
+        raise TypeError("stack_index must contain integer stack ids only")
+    return stack_index
+
+
+def _normalize_stack_names(stack_names: StackNameSelection) -> tuple[str, ...]:
+    if isinstance(stack_names, str):
+        return (stack_names,)
+    stack_names = tuple(stack_names)
+    if not stack_names:
+        raise ValueError("At least one MSR stack name is required")
+    if any(not isinstance(name, str) for name in stack_names):
+        raise TypeError("stack_names must contain string stack names only")
+    return stack_names
+
+
+def _resolve_stack_indices(msr, stack_selection: StackSelection) -> tuple[int, ...]:
+    resolved = []
+    for stack in _normalize_stack_selection(stack_selection):
+        if isinstance(stack, int):
+            resolved.append(stack)
+        else:
+            resolved.append(msr.stack_names.index(stack))
+    return tuple(resolved)
+
+
+def _get_msr_stack_shape(msr_path: PathLike, stack_selection: StackSelection = 0) -> tuple[int, int]:
+    _require_msr_reader()
+    with OBFFile(os.fspath(msr_path)) as msr:
+        stack_index = _resolve_stack_indices(msr, stack_selection)[0]
+    return tuple(_read_msr_stack(msr_path, stack_index=stack_index).shape)
+
+
+def _resolve_stack_indices_for_path(msr_path: PathLike, stack_selection: StackSelection) -> tuple[int, ...]:
+    _require_msr_reader()
+    with OBFFile(os.fspath(msr_path)) as msr:
+        return _resolve_stack_indices(msr, stack_selection)
+
+
+class MSRSampleCollection:
+    """Collection-like helper for loading one sample per MSR file."""
+
+    def __init__(
+        self,
+        image_paths: Sequence[PathLike],
+        stack_index: StackIndexSelection = 0,
+        stack_names: StackNameSelection | None = None,
+    ):
+        self.image_paths = [os.fspath(path) for path in image_paths]
+        if stack_names is not None and stack_index != 0:
+            raise ValueError("Pass either stack_index or stack_names, not both.")
+        if stack_names is not None:
+            self.stack_selection = _normalize_stack_names(stack_names)
+        else:
+            self.stack_selection = _normalize_stack_indices(stack_index)
+        self.stack_indices = _resolve_stack_indices_for_path(self.image_paths[0], self.stack_selection)
+        sample = _read_msr_stack(self.image_paths[0], self.stack_indices[0])
+        self._dtype = sample.dtype
+        self._shape = sample.shape if len(self.stack_indices) == 1 else (len(self.stack_indices),) + tuple(sample.shape)
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @property
+    def ndim(self):
+        return len(self._shape)
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def chunks(self):
+        return None
+
+    @property
+    def size(self):
+        return int(np.prod(self._shape))
+
+    @property
+    def attrs(self):
+        return {}
+
+    def read_sample(self, index: int) -> np.ndarray:
+        stack_indices = _resolve_stack_indices_for_path(self.image_paths[index], self.stack_selection)
+        if len(stack_indices) == 1:
+            return _read_msr_stack(self.image_paths[index], stack_indices[0])
+        data = [_read_msr_stack(self.image_paths[index], stack_index) for stack_index in stack_indices]
+        return np.stack(data, axis=0)
+
+
+class MSRFile(Mapping):
+    """Root object for a file handle representing an MSR file."""
+
+    def __init__(self, path: PathLike, mode: str = "r"):
+        _require_msr_reader()
+        if mode != "r":
+            raise ValueError("MSR files only support read mode.")
+        self.path = os.fspath(path)
+        self.mode = mode
+        self.msr = OBFFile(self.path)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self):
+        self.msr.close()
+
+    @property
+    def attrs(self):
+        return {}
+
+    def _normalize_key(self, key):
+        if key == "data":
+            return key
+        try:
+            return int(key)
+        except (TypeError, ValueError):
+            if key in self.msr.stack_names:
+                return self.msr.stack_names.index(key)
+            raise KeyError(f"Could not find key {key}")
+
+    def __getitem__(self, key):
+        key = self._normalize_key(key)
+        if key == "data":
+            return MSRDataset(self.path, tuple(range(self.msr.num_stacks)))
+        return MSRDataset(self.path, key)
+
+    def __iter__(self):
+        for index in range(self.msr.num_stacks):
+            yield str(index)
+        yield "data"
+
+    def __len__(self):
+        return self.msr.num_stacks + 1
+
+    def __contains__(self, name):
+        if name == "data":
+            return True
+        try:
+            index = int(name)
+            return 0 <= index < self.msr.num_stacks
+        except (TypeError, ValueError):
+            return name in self.msr.stack_names
+
+
+class MSRDataset:
+    """Dataset object for one or more stacks in a single MSR file."""
+
+    def __init__(self, path: PathLike, stack_selection: StackSelection):
+        self.path = os.fspath(path)
+        self.stack_selection = _normalize_stack_selection(stack_selection)
+
+        with OBFFile(self.path) as msr:
+            self.stack_indices = _resolve_stack_indices(msr, self.stack_selection)
+            sample = msr.read_stack(self.stack_indices[0])
+
+        if sample.ndim != 2:
+            raise ValueError(f"Expected a 2D MSR stack from {self.path}, got shape {sample.shape}")
+
+        self._dtype = sample.dtype
+        self._shape = sample.shape if len(self.stack_indices) == 1 else (len(self.stack_indices),) + sample.shape
+        self._size = int(np.prod(self._shape))
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @property
+    def ndim(self):
+        return len(self._shape)
+
+    @property
+    def chunks(self):
+        return None
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def attrs(self):
+        return {}
+
+    def _read_stack(self, stack_index: int, spatial_index):
+        with OBFFile(self.path) as msr:
+            data = msr.read_stack(stack_index)
+        return data[spatial_index]
+
+    def __getitem__(self, key):
+        key, to_squeeze = normalize_index(key, self.shape)
+        if len(self.stack_indices) == 1:
+            data = self._read_stack(self.stack_indices[0], key)
+            return squeeze_singletons(data, to_squeeze).copy()
+
+        channel_index, spatial_index = key[0], key[1:]
+        channel_step = 1 if channel_index.step is None else channel_index.step
+        data = [
+            self._read_stack(stack_index, spatial_index)
+            for stack_index in self.stack_indices[channel_index.start:channel_index.stop:channel_step]
+        ]
+        return squeeze_singletons(np.stack(data, axis=0), to_squeeze).copy()

--- a/test/io_tests/test_msr_wrapper.py
+++ b/test/io_tests/test_msr_wrapper.py
@@ -1,0 +1,118 @@
+import os
+import unittest
+from pathlib import Path
+from shutil import copyfile, copyfileobj, rmtree
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import numpy as np
+
+try:
+    from msr_reader import OBFFile
+except ImportError:
+    OBFFile = None
+
+
+@unittest.skipIf(OBFFile is None, "Needs msr_reader")
+class TestMSRWrapper(unittest.TestCase):
+    sample_url = "https://owncloud.gwdg.de/index.php/s/3WZ5DDBCQqyU2Jj/download"
+    tmp_dir = "./tmp"
+    sample_path = Path(tmp_dir) / "sample.msr"
+    sample_path_1 = Path(tmp_dir) / "sample_1.msr"
+    sample_path_2 = Path(tmp_dir) / "sample_2.msr"
+
+    @classmethod
+    def setUpClass(cls):
+        os.makedirs(cls.tmp_dir, exist_ok=True)
+        if not cls.sample_path.exists():
+            try:
+                with urlopen(cls.sample_url, timeout=120) as src, open(cls.sample_path, "wb") as dst:
+                    copyfileobj(src, dst)
+            except URLError as exc:
+                raise unittest.SkipTest(f"Could not download MSR test data: {exc}")
+
+        copyfile(cls.sample_path, cls.sample_path_1)
+        copyfile(cls.sample_path, cls.sample_path_2)
+
+        with OBFFile(os.fspath(cls.sample_path)) as msr:
+            cls.overview_name = msr.stack_names[0]
+            cls.pre_name = msr.stack_names[6]
+            cls.post_name = msr.stack_names[7]
+            cls.overview = msr.read_stack(0)
+            cls.pre = msr.read_stack(6)
+            cls.post = msr.read_stack(7)
+            cls.pre_post = np.stack([cls.pre, cls.post], axis=0)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            rmtree(cls.tmp_dir)
+        except OSError:
+            pass
+
+    def test_dataset_single_stack(self):
+        from elf.io import MSRDataset
+
+        ds = MSRDataset(self.sample_path, self.pre_name)
+        self.assertEqual(ds.shape, self.pre.shape)
+        self.assertEqual(ds.dtype, self.pre.dtype)
+        self.assertEqual(ds.size, self.pre.size)
+        self.assertEqual(ds.ndim, self.pre.ndim)
+
+        for bb in (np.s_[:], np.s_[10:32, 15:48]):
+            self.assertTrue(np.array_equal(ds[bb], self.pre[bb]))
+
+    def test_dataset_multiple_stacks(self):
+        from elf.io import MSRDataset
+
+        ds = MSRDataset(self.sample_path, (self.pre_name, self.post_name))
+        self.assertEqual(ds.shape, self.pre_post.shape)
+        self.assertEqual(ds.dtype, self.pre_post.dtype)
+        self.assertEqual(ds.size, self.pre_post.size)
+        self.assertEqual(ds.ndim, self.pre_post.ndim)
+
+        for bb in (np.s_[:], np.s_[:, 10:32, 15:48], 1):
+            self.assertTrue(np.array_equal(ds[bb], self.pre_post[bb]))
+
+    def test_sample_collection(self):
+        from elf.io import MSRSampleCollection
+
+        collection = MSRSampleCollection(
+            [self.sample_path_1, self.sample_path_2],
+            stack_names=(self.pre_name, self.post_name),
+        )
+        self.assertEqual(collection.shape, self.pre_post.shape)
+        self.assertEqual(collection.dtype, self.pre_post.dtype)
+        self.assertEqual(collection.size, self.pre_post.size)
+        self.assertEqual(collection.ndim, self.pre_post.ndim)
+        self.assertIsNone(collection.chunks)
+        self.assertEqual(collection.attrs, {})
+
+        self.assertTrue(np.array_equal(collection.read_sample(0), self.pre_post))
+        self.assertTrue(np.array_equal(collection.read_sample(1), self.pre_post))
+
+    def test_file(self):
+        from elf.io import MSRFile
+
+        with MSRFile(self.sample_path) as f:
+            self.assertIn("0", f)
+            self.assertIn("6", f)
+            self.assertIn(self.pre_name, f)
+            self.assertIn("data", f)
+            self.assertEqual(len(f), 9)
+
+            self.assertTrue(np.array_equal(f["0"][:], self.overview))
+            self.assertTrue(np.array_equal(f["6"][:], self.pre))
+            self.assertTrue(np.array_equal(f[self.pre_name][:], self.pre))
+            self.assertTrue(np.array_equal(f[self.post_name][:], self.post))
+
+    def test_open_file(self):
+        from elf.io import open_file, MSRFile
+
+        with open_file(self.sample_path) as f:
+            self.assertIsInstance(f, MSRFile)
+            self.assertTrue(np.array_equal(f[self.pre_name][:], self.pre))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi @constantinpape,

I was thinking about this for sometime now (msr file wrapper). In short, I made a file wrapper for `.msr` file format (abberior microscope file format). It does support file object construction, so I decided to write a proper file wrapper for one file (`MSRDataset`) / multiple msr files (`MSRSampleCollection`), since using `MultiDataWrapper` is slightly tricky due to varied hierarchy nomenclature support in `.msr` files.

This is currently most relevant for Oleg, since I noticed his dataset preparation hits CPU memory limits (he's currently playing at a huge scale) and lazy loading would be the "only" way-to-go for his STED data, also having the msr file wrapper might be interesting for us in the coming future too! ;)

I wanna hear your thoughts on this. What do you think about this?